### PR TITLE
Add a search / jump to Pokémon function

### DIFF
--- a/GPX+ Shiny Tracker Minimalist.html
+++ b/GPX+ Shiny Tracker Minimalist.html
@@ -9,8 +9,9 @@
     <link rel="stylesheet" type="text/css" href="Style.css">
     <link rel="icon" href="Images/Main/Sparkles.png">
     <script src="Script-ClickProgress.js"></script>
+    <script defer src="Script-SearchBar.js"></script>
     <script>
-        window.onload = function () { markAll(); }
+        window.onload = function () { markAll(); addTabIndex(); addSearch(); }
     </script>
 </head>
 

--- a/GPX+ Shiny Tracker Minimalist.html
+++ b/GPX+ Shiny Tracker Minimalist.html
@@ -18,6 +18,8 @@
 <body id="top">
     <header>
         <img src="Images/Main/Minimalist-Banner.png" alt="Tracker Version Banner">
+    </header>
+    <section class="sidebar">
         <nav class="menu">
             <div class="head">Navigation & Collection</div>
             <ul id="progressBars">
@@ -45,7 +47,7 @@
                 <progress value="0" max="130" title="0/130"></progress>
             </ul>
         </nav>
-    </header>
+    </section>
     <main id="mark"><!-- this <main> must contain no images other than Pokémon to be marked by JS! -->
         <div class="head">Information on the Minimalist Edition</div>
         <div class="body">

--- a/GPX+ Shiny Tracker Standard.html
+++ b/GPX+ Shiny Tracker Standard.html
@@ -9,8 +9,9 @@
     <link rel="stylesheet" type="text/css" href="Style.css">
     <link rel="icon" href="Images/Main/Sparkles.png">
     <script src="Script-ClickProgress.js"></script>
+    <script defer src="Script-SearchBar.js"></script>
     <script>
-        window.onload = function () { markAll(); }
+        window.onload = function () { markAll(); addTabIndex(); addSearch(); }
     </script>
 </head>
 

--- a/GPX+ Shiny Tracker Standard.html
+++ b/GPX+ Shiny Tracker Standard.html
@@ -18,6 +18,8 @@
 <body id="top">
     <header>
         <img src="Images/Main/Standard-Banner.png" alt="Tracker Version Banner">
+    </header>
+    <section class="sidebar">
         <nav class="menu">
             <div class="head">Navigation & Collection</div>
             <ul id="progressBars">
@@ -45,7 +47,7 @@
                 <progress value="0" max="230" title="0/230"></progress>
             </ul>
         </nav>
-    </header>
+    </section>
     <main id="mark"><!-- this <main> must contain no images other than Pokémon to be marked by JS! -->
         <div class="head">Information on the Standard Edition</div>
         <div class="body">

--- a/GPX+ Shiny Tracker Ultimate.html
+++ b/GPX+ Shiny Tracker Ultimate.html
@@ -9,8 +9,9 @@
     <link rel="stylesheet" type="text/css" href="Style.css">
     <link rel="icon" href="Images/Main/Sparkles.png">
     <script src="Script-ClickProgress.js"></script>
+    <script defer src="Script-SearchBar.js"></script>
     <script>
-        window.onload = function () { markAll(); }
+        window.onload = function () { markAll(); addTabIndex(); addSearch(); }
     </script>
 </head>
 

--- a/GPX+ Shiny Tracker Ultimate.html
+++ b/GPX+ Shiny Tracker Ultimate.html
@@ -18,6 +18,8 @@
 <body id="top">
     <header>
         <img src="Images/Main/Ultimate-Banner.png" alt="Tracker Version Banner">
+    </header>
+    <section class="sidebar">
         <nav class="menu">
             <div class="head">Navigation & Collection</div>
             <ul id="progressBars">
@@ -45,7 +47,7 @@
                 <progress value="0" max="237" title="0/237"></progress>
             </ul>
         </nav>
-    </header>
+    </section>
     <main id="mark"><!-- this <main> must contain no images other than Pokémon to be marked by JS! -->
         <div class="head">Information on the Ultimate Edition</div>
         <div class="body">

--- a/Getting Started.html
+++ b/Getting Started.html
@@ -17,6 +17,8 @@
 <body>
     <header>
         <img src="Images/Getting Started/Banner.png" alt="Tracker Version Banner">
+    </header>
+    <section class="sidebar">
         <nav class="menu">
             <div class="head">Open Your Shiny Tracker</div>
             <ul>
@@ -33,7 +35,7 @@
                 <li><a href="#Thanks">Thank You!</a></li>
             </ul>
         </nav>
-    </header>
+    </section>
     <main>
         <div class="head">The Welcome Section</div>
         <div class="body">

--- a/Getting Started.html
+++ b/Getting Started.html
@@ -455,6 +455,20 @@
                     </ul>
                 </div>
             </details>
+            <details>
+                <summary>How do I search for Pokémon?</summary>
+                <div class="body-small">
+                    <p>Just type in the box and click the Find it! button, and you should be taken right to the Pokémon!</p>
+                    <p>The search box looks for the <em>first</em> Pokémon whose name starts with what you wrote. It also
+                        works in lowercase. So if you type "mag", or "Mag", Magnemite will be shown for you, but not
+                        Magneton, Magnezone or Magearna. But if you type "mage", you'll get right to Magearna! It's like
+                        the search text always has a wildcard character on the end.</p>
+                    <p>You do need to know a Pokémon's name, including form. By typing "altaria" you can get to Altaria
+                        but also Altaria [Mega], since it has the same Pokédex number, so it's right nearby. But you
+                        won't get to Altaria [Constellation], or Zhenyin, because they are listed under Novelty Pokémon
+                        and not Generation III. You could find those two by typing "altaria [c", or just "zh".</p>
+                </div>
+            </details>
         </div>
         <div class="head">Thank You!</div>
         <div class="body">

--- a/Script-ClickProgress.js
+++ b/Script-ClickProgress.js
@@ -131,6 +131,20 @@ function mark(elem, generation, state = "own", count_now = true) {
     if ( count_now ) { countProgress(generation); }
 }
 
+function markThis(event){
+    clickState = localStorage.getItem("shiny ".concat(event.target.alt));
+    gen = event.target.parentElement.classList[1];
+    if (clickState !== null) {
+        mark(event.target, gen, "notown", true);
+        /* if there was any stored status, treat it as own. Then we want
+        to set the _opposite_ status, i.e. notown. */
+    } else {
+        mark(event.target, gen, "own", true);
+        /* if there was no stored status, the existing status is notown
+        (as the default), so we set to own. */
+    }
+}
+
 function markAll() {
     const elems = document.getElementById("mark").querySelectorAll('img:not([src="Images/Pokémon/0.png"])');
     /* an extra class on each img would be necessary if there were any img elements
@@ -144,20 +158,12 @@ function markAll() {
         generation and state) in an array, then give that array to Promise.all(). But
         performance does not seem to demand it at the minute. See:
         https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Promises#combining_multiple_promises */
-        elems[i].addEventListener('click', function () {
-            clickState = localStorage.getItem("shiny ".concat(this.alt));
-            gen = this.parentElement.classList[1];
-            if (clickState !== null) {
-                mark(this, gen, "notown", true);
-                /* if there was any stored status, treat it as own. Then we want
-                to set the _opposite_ status, i.e. notown. */
-            } else {
-                mark(this, gen, "own", true);
-                /* if there was no stored status, the existing status is notown
-                (as the default), so we set to own. */
+        elems[i].addEventListener('click', (ev) => markThis(ev));
+        elems[i].addEventListener("keydown", function (ev) {
+            if (ev.key === "Enter") {  //checks whether the pressed key is "Enter"
+                markThis(ev);
             }
         });
-
         let prevState = localStorage.getItem("shiny ".concat(elems[i].alt));
         if (prevState !== null) {
             mark(elems[i], elems[i].parentElement.classList[1], "own", false);

--- a/Script-ClickProgress.js
+++ b/Script-ClickProgress.js
@@ -1,3 +1,5 @@
+// By Cycloneblaze.
+
 function countProgress(generation) {
     //TODO: can I change this from a switch to a function that takes the class as argument, and deduplicate? 
     console.log("generation was", generation)

--- a/Script-ClickProgress.js
+++ b/Script-ClickProgress.js
@@ -159,7 +159,7 @@ function markAll() {
         performance does not seem to demand it at the minute. See:
         https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Promises#combining_multiple_promises */
         elems[i].addEventListener('click', (ev) => markThis(ev));
-        elems[i].addEventListener("keydown", function (ev) {
+        elems[i].addEventListener("keyup", function (ev) {
             if (ev.key === "Enter") {  //checks whether the pressed key is "Enter"
                 markThis(ev);
             }

--- a/Script-SearchBar.js
+++ b/Script-SearchBar.js
@@ -73,4 +73,12 @@ function addSearch() {
       searchBoxText.style = "display: initial; color: #ff7c7c;";
     }
   }
+  // Add an event listener for the Enter key to the search box:
+  searchBoxBox.addEventListener("keyup", function(event) {
+    event.preventDefault();
+    if (event.key === "Enter") {
+      // if we get it, click the Search button
+        searchBoxButton.click();
+    }
+  });
 }

--- a/Script-SearchBar.js
+++ b/Script-SearchBar.js
@@ -40,8 +40,7 @@ function addSearch() {
   searchBoxBox.setAttribute("placeholder", "Totodile");
   const searchBoxText = document.createElement("p");
   searchBoxText.classList.add("searchInfo");
-  searchBoxText.style = "display: none;";
-  let searchBoxTextText = document.createTextNode("");
+  let searchBoxTextText = document.createTextNode("Search forms with [], e.g. 'altaria [c'.");
   searchBoxText.appendChild(searchBoxTextText);
   const searchBoxButton = document.createElement("button");
   searchBoxButton.setAttribute("name", "searchb");

--- a/Script-SearchBar.js
+++ b/Script-SearchBar.js
@@ -38,6 +38,11 @@ function addSearch() {
   searchBoxBox.setAttribute("type", "search");
   searchBoxBox.setAttribute("name", "searchv");
   searchBoxBox.setAttribute("placeholder", "Totodile");
+  const searchBoxText = document.createElement("p");
+  searchBoxText.classList.add("searchInfo");
+  searchBoxText.style = "display: none;";
+  let searchBoxTextText = document.createTextNode("");
+  searchBoxText.appendChild(searchBoxTextText);
   const searchBoxButton = document.createElement("button");
   searchBoxButton.setAttribute("name", "searchb");
   searchBoxButton.setAttribute("id", "searchButton");
@@ -45,10 +50,12 @@ function addSearch() {
   searchBoxButton.appendChild(searchBoxButtonText);
   searchBox.append(searchBoxBox);
   searchBox.append(searchBoxButton);
+  searchBox.append(searchBoxText);
   theNav.append(searchBox);
   // Add an anonymous function to the button's onclick attribute:
   searchBoxButton.onclick = () => {
-    let searchValue = document.getElementById("searchText").value.normalize("NFD").replace(/\p{Diacritic}/gu, "").toLowerCase();
+    let uSearchValue = document.getElementById("searchText").value
+    let searchValue = uSearchValue.normalize("NFD").replace(/\p{Diacritic}/gu, "").toLowerCase();
     // Get the search string we want to use, and normalise it.
     const searchTargets = Array.from(document.querySelectorAll('main img:not([src="Images/Pokémon/0.png"])'));
     // Get the list of all non-placeholder Pokémon, convert it to an array.
@@ -59,8 +66,11 @@ function addSearch() {
       /* Focus the searchTarget to highlight it as the search result.
       Don't scroll to it, because we want to do a nicer scroll ourselves with: */
       searchTarget.scrollIntoView({ behavior: "smooth", block: "center" });
+      searchBoxText.innerText = "Click the Pokémon to mark it as owned!"
+      searchBoxText.style = "display: initial; color: #fff;";
     } else {
-      console.log("Couldn't find a Pokémon whose alt started with", searchValue);
+      searchBoxText.innerText = "Couldn't find a name starting with '" + uSearchValue + "'!";
+      searchBoxText.style = "display: initial; color: #ff7c7c;";
     }
   }
 }

--- a/Script-SearchBar.js
+++ b/Script-SearchBar.js
@@ -1,0 +1,66 @@
+// By Cycloneblaze.
+
+/* Add a tabindex attribute to all images. As well as allowing them to be
+   focused upon (which <img>s normally cannot), which allows the below
+   function to work, it also allows you to tab through the images,
+   enabling keyboard navigation which is good for accessibility. It would
+   be very tedious to add an incrementing "tabindex" attribute on every
+   image by hand, though, and impossible to update it when you added a
+   new Pokémon in the middle! So let's add them with javascript. */ 
+function addTabIndex() {
+  const targets = Array.from(document.querySelectorAll('main img:not([src="Images/Pokémon/0.png"])'));
+  // Get the list of all non-placeholder Pokémon, convert it to an array.
+  for (let i = 0; i < targets.length; i++) {
+    targets[i].setAttribute("tabindex", i);
+    /* Since each image gets tabindex=its position in the list of targets,
+       the user can tab through them in order all the way down the page.*/
+  }
+}
+
+// Add the search bar box with JS. That way if it appears, you can use it.
+function addSearch() {
+  // Create a new div element:
+  const searchHead = document.createElement("div");
+  // Style it with a class:
+  searchHead.classList.add("head");
+  // And give it some content:
+  const searchHeadText = document.createTextNode("Jump to a Pokémon");
+  // Add the text node to the newly created div:
+  searchHead.appendChild(searchHeadText);
+  // Add the newly created element and its content into the DOM:
+  const theNav = document.getElementsByTagName("nav")[0]; // assume only one nav, else we have to put an ID on the nav
+  theNav.append(searchHead);
+  // Repeat!
+  const searchBox = document.createElement("div");
+  searchBox.classList.add("search");
+  const searchBoxBox = document.createElement("input");
+  searchBoxBox.setAttribute("id", "searchText");
+  searchBoxBox.setAttribute("type", "search");
+  searchBoxBox.setAttribute("name", "searchv");
+  searchBoxBox.setAttribute("placeholder", "Totodile");
+  const searchBoxButton = document.createElement("button");
+  searchBoxButton.setAttribute("name", "searchb");
+  searchBoxButton.setAttribute("id", "searchButton");
+  const searchBoxButtonText = document.createTextNode("Find it!");
+  searchBoxButton.appendChild(searchBoxButtonText);
+  searchBox.append(searchBoxBox);
+  searchBox.append(searchBoxButton);
+  theNav.append(searchBox);
+  // Add an anonymous function to the button's onclick attribute:
+  searchBoxButton.onclick = () => {
+    let searchValue = document.getElementById("searchText").value.normalize("NFD").replace(/\p{Diacritic}/gu, "").toLowerCase();
+    // Get the search string we want to use, and normalise it.
+    const searchTargets = Array.from(document.querySelectorAll('main img:not([src="Images/Pokémon/0.png"])'));
+    // Get the list of all non-placeholder Pokémon, convert it to an array.
+    let searchTarget = searchTargets.find((img) => img.alt.normalize("NFD").replace(/\p{Diacritic}/gu, "").toLowerCase().startsWith(searchValue));
+    // The first img in searchTargets where img.alt.normalize("NFD").replace(/\p{Diacritic}/gu, "").toLowerCase() === searchValue.
+    if ( searchTarget != null ) { 
+      searchTarget.focus({ preventScroll: true });
+      /* Focus the searchTarget to highlight it as the search result.
+      Don't scroll to it, because we want to do a nicer scroll ourselves with: */
+      searchTarget.scrollIntoView({ behavior: "smooth", block: "center" });
+    } else {
+      console.log("Couldn't find a Pokémon whose alt started with", searchValue);
+    }
+  }
+}

--- a/Style.css
+++ b/Style.css
@@ -1,18 +1,28 @@
-html,
+html {
+    /* Scrollbar design. */
+    scrollbar-color: #424242 #262626;
+    scrollbar-width: thin;
+    /* End */
+}
+
 body {
     height: 100%;
     margin: 0;
     padding: 0;
 
+    /* Page layout. */
+    display: grid;
+    grid-template-areas:
+        "sidebar header"
+        "sidebar main"
+        "footer footer";
+    grid-template-columns: 2fr 11fr;
+    grid-template-rows: auto 1fr auto;
+
     /* Main background. */
     background-color: #141414;
     background-image: url(Images/Main/Background.png);
     background-repeat: repeat;
-    /* End */
-
-    /* Scrollbar design. */
-    scrollbar-color: #424242 #262626;
-    scrollbar-width: thin;
     /* End */
 
     /* Font design. */
@@ -34,7 +44,7 @@ body {
 }
 /* End */
 
-    /* List design. */
+/* List design. */
 ul.list {
     list-style-image: url(Images/Main/Menu.png);
     text-align: left;
@@ -51,22 +61,23 @@ ul.list li {
 header {
     padding: 50px 0px;
     text-align: center;
+    grid-area: header;
 }
 /* End */
 
 /* Middle section - Container that holds the PC Icons. */
 main {
-    float: right;
-    width: 80%;
     margin-left: 2%;
     margin-right: 2%;
     margin-bottom: 2%;
+    grid-area: main;
 }
 /* End */
 
 /* End section - Notes. */
 footer {
     clear: both;
+    grid-area: footer;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -128,13 +139,14 @@ div.subtitle {
 /* End */
 
 /* Quick Jump Menu.*/
+section.sidebar {
+    grid-area: sidebar;
+}
+
 nav.menu {
-    float: left;
-    position: fixed;
-    width: 15%;
-    margin-left: 1%;
-    top: 10%;
-    text-align: left;
+	position: sticky;
+	margin-left: 2em;
+	top: 2em;
 }
 
 nav.menu ul {
@@ -194,6 +206,10 @@ nav.menu div.search {
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
+}
+
+div.search input {
+    width: 70%;
 }
 
 p.searchInfo {

--- a/Style.css
+++ b/Style.css
@@ -184,6 +184,19 @@ progress::-webkit-progress-value {
 /* End */
 
 
+/* Search Bar display */
+nav.menu div.search {
+    margin: 0;
+    padding: 10px 30px;
+    background: #2b2f30;
+    border: 1px solid black;
+    border-top: 0;
+    display: flex;
+    justify-content: space-between;
+}
+
+/* End */
+
 
 /* PC Box Icon opacity */
 img.own {
@@ -202,7 +215,7 @@ img.notown:focus {
 
 /* PC Box Info - Displays when hovering over Icons */
 div.pkmn:hover,
-div.pkmn:focus {
+div.pkmn:focus-within {
     -webkit-box-shadow: 0px 0px 3px 2px rgba(255, 255, 255, 0.59);
     box-shadow: 0px 0px 3px 2px rgba(255, 255, 255, 0.59);
 }
@@ -231,7 +244,7 @@ div.pkmn span.info-expand {
 }
 
 div.pkmn:hover span.info, div.pkmn:hover span.info-expand,
-div.pkmn:focus span.info, div.pkmn:focus span.info-expand {
+div.pkmn:focus-within span.info, div.pkmn:focus-within span.info-expand {
     visibility: visible;
 }
 

--- a/Style.css
+++ b/Style.css
@@ -28,7 +28,7 @@ body {
         text-decoration: none;
     }
 
-    a:hover {
+    a:hover, a:focus {
         text-decoration: underline;
     }
 }
@@ -194,13 +194,15 @@ img.notown {
     opacity: 0.3;
 }
 
-img.notown:hover {
+img.notown:hover,
+img.notown:focus {
     opacity: 1.0;
 }
 /* End */
 
 /* PC Box Info - Displays when hovering over Icons */
-div.pkmn:hover {
+div.pkmn:hover,
+div.pkmn:focus {
     -webkit-box-shadow: 0px 0px 3px 2px rgba(255, 255, 255, 0.59);
     box-shadow: 0px 0px 3px 2px rgba(255, 255, 255, 0.59);
 }
@@ -228,7 +230,8 @@ div.pkmn span.info-expand {
     width: 260px;
 }
 
-div.pkmn:hover span.info, div.pkmn:hover span.info-expand {
+div.pkmn:hover span.info, div.pkmn:hover span.info-expand,
+div.pkmn:focus span.info, div.pkmn:focus span.info-expand {
     visibility: visible;
 }
 

--- a/Style.css
+++ b/Style.css
@@ -192,7 +192,15 @@ nav.menu div.search {
     border: 1px solid black;
     border-top: 0;
     display: flex;
+    flex-wrap: wrap;
     justify-content: space-between;
+}
+
+p.searchInfo {
+    font-size: smaller;
+    text-align: center;
+    margin: 1ch 0 0;
+    width: 100%;
 }
 
 /* End */
@@ -207,10 +215,9 @@ img.notown {
     opacity: 0.3;
 }
 
-img.notown:hover,
-img.notown:focus {
+img.notown:hover {
     opacity: 1.0;
-}
+} /* Opacity still 0.3 when focused to provide a visual difference when searching. */
 /* End */
 
 /* PC Box Info - Displays when hovering over Icons */


### PR DESCRIPTION
Answers [this request](https://forums.gpx.plus/index.php?s=&showtopic=78892&view=findpost&p=2509804). As I noted there I figured it was inappropriate to leave a search function like this to Ctrl+F; right now that doesn't work, and to make it work we'd have to add text to the web page that's always visible with the name of each Pokémon. So instead I made a Javascript function using a search bar which searches in the alt text attribute of each image. We know we can use alt because we already use it to track the own/not owned state.

You can see how it works in the script, or I wrote a little usage guide in the getting started file, but two things to note. First, the search bar is actually added by Javascript, it's not in the HTML file(s). Instead, a new function at the top of the HTML file adds it in. It's not necessary to do it this way, but now if you don't have JS active or didn't download the JS file, the search bar won't appear at all, instead of it being there but not working.

Secondly, I added another function which adds a "tabindex" attribute to all Pokémon images. This is necessary to be able to focus on the images which is necessary for the search to highlight them (you can't normally tab to an <img>). But it also allows users with keyboards to tab through all the Pokémon and mark them with their keyboard. The search bar makes keyboard use a lot easier too; it's a bit tedious to tab through 400 Pokémon to get to Blaziken. The last thing necessary to make keyboard navigation possible is to make the mark function work on Enter as well, so I also did that. I'm quite happy with the incidental accessibility win here!

Finally, I've added a v4.2 branch as merge target so you can save this feature for the next versioned update of the tracker. 🙂